### PR TITLE
	Update Windshaft installation process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,1 @@
-.git/
-.travis/
-.travis.yml
-Dockerfile
-README.md
+*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - docker build -t quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${TRAVIS_COMMIT:0:7} .
 
 script:
-  - "/bin/true"
+  - docker run --rm quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${TRAVIS_COMMIT:0:7} --version
 
 before_deploy:
   - docker login -e . -p "${QUAY_PASSWORD}" -u "${QUAY_USER}" quay.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,14 @@ FROM node:0.10-slim
 
 MAINTAINER Azavea <systems@azavea.com>
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+ENV WINDSHAFT_VERSION 0.36.0
+
+RUN mkdir -p /opt/windshaft
+
+WORKDIR /opt/windshaft
+
+RUN set -ex \
+  && buildDeps=' \
     build-essential \
     git-core \
     libcairo2-dev \
@@ -10,14 +17,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libjpeg62-turbo-dev \
     libgif-dev \
     libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /opt/windshaft
-WORKDIR /opt/windshaft
-COPY . /opt/windshaft
-
-# NB: the most recent versions do not work with the provided configurations
-RUN npm install --unsafe-perm windshaft@0.36.0
+	' \
+  && apt-get update && apt-get install -y ${buildDeps} --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && npm install --unsafe-perm windshaft@${WINDSHAFT_VERSION} \
+  && apt-get purge -y --auto-remove ${buildDeps}
 
 EXPOSE 5000
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,12 @@ A `Dockerfile` based off of [`node:0.10-slim`](https://registry.hub.docker.com/_
 First, build the container:
 
 ```bash
-$ docker build -t azavea/windshaft .
+$ docker build -t quay.io/azavea/windshaft:latest .
 ```
 
 From there you can run a container with:
 
 ```bash
-$ docker run \
-    --rm \
-    --volume ${PWD}/server.js:/opt/windshaft/server.js \
-    azavea/windshaft server.js
+$ docker run --rm -v ${PWD}/server.js:/opt/windshaft/server.js \
+    quay.io/azavea/windshaft:latest server.js
 ```


### PR DESCRIPTION
Remove build dependencies after a successful installation to reduce the image footprint. Also, simplify the Docker ignore file and ensure test suite exercises Node.
