### PR TITLE
Fix dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,14 @@ RUN set -ex \
     libjpeg62-turbo-dev \
     libgif-dev \
     libpq-dev \
-	' \
-  && apt-get update && apt-get install -y ${buildDeps} --no-install-recommends \
+    ' \
+  && deps=' \
+    libcairo2 \
+    libgif4 \
+    libjpeg62-turbo \
+    libpixman-1-0 \
+    ' \
+  && apt-get update && apt-get install -y ${buildDeps} ${deps} --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && npm install --unsafe-perm windshaft@${WINDSHAFT_VERSION} \
   && apt-get purge -y --auto-remove ${buildDeps}

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ First, build the container:
 $ docker build -t quay.io/azavea/windshaft:latest .
 ```
 
-From there you can run a container with:
+From there, assuming you have a local Windshaft server at `server/server.js`, you can run a container with:
 
 ```bash
-$ docker run --rm -v ${PWD}/server.js:/opt/windshaft/server.js \
-    quay.io/azavea/windshaft:latest server.js
+$ docker run --rm -v ${PWD}/server:/opt/windshaft/server/ \
+    quay.io/azavea/windshaft:latest server/server.js
 ```


### PR DESCRIPTION
Libraries required by node-cairo were removed in #1. This PR separates out the run-time dependencies from the build dependencies so they are not removed after installation.

Also, the README is updated to fix the test instruction command.

**Testing instructions**
- Build the container.
- Add this sample `server.js` to a `sample` directory in the repo:

```
var Windshaft = require('windshaft');

var dbUser = process.env.POSTGRES_USER,
    dbPass = process.env.POSTGRES_PASSWORD,
    dbHost = process.env.POSTGRES_HOST,
    dbName = process.env.POSTGRES_DB,
    dbPort = process.env.POSTGRES_PORT;

var config = {
    base_url: '/database/:dbname/table/:table',
    base_url_notable: '/database/:dbname',
    grainstore: {
          datasource: {
              dbname: dbName,
              user: dbUser,
              host: dbHost,
              port: dbPort,
              password: dbPass,
              geometry_field: 'geom',
              srid: 4326
        }
    },
    redis: {
        host: process.env.REDIS_HOST,
        port: process.env.REDIS_PORT
    },
    enable_cors: true,
    req2params: function(req, callback) {
        req.params.interactivity = null;

        callback(null, req);
    },
};

// Initialize tile server on port 5000
var ws = new Windshaft.Server(config);
ws.listen(5000);
console.log('Starting Windshaft tiler on http://localhost:5000' + config.base_url + '/:z/:x/:y.*');
```
- Use the command in the revised README to run the server.
- Verify that the server starts up without any errors.
